### PR TITLE
Including an etherpad link for the workshop

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ enddate: 2020-02-11        # machine-readable end date for the workshop in YYYY-
 instructor: ["Joni Pelham, Malvika Sharan"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: ["Louise Bowler, Kasra Hosseini, James Robinson"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 email: ["lbowler@turing.ac.uk"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
-collaborative_notes:             # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document (e.g., https://pad.carpentries.org/2015-01-01-euphoria)
+collaborative_notes: https://pad.carpentries.org/2020-02-10-turing        # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document (e.g., https://pad.carpentries.org/2015-01-01-euphoria)
 eventbrite:           # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
 ---
 


### PR DESCRIPTION
We will use this link for collaborative documentation: https://pad.carpentries.org/2020-02-10-turing