### PR TITLE
Renamed the workshop header to SwC

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: workshop      # DON'T CHANGE THIS.
-venue: "The Alan Turing Institute"        # brief name of host site without address (e.g., "Euphoric State University")
+venue: "Software Carpentry Workshop, The Alan Turing Institute"        # brief name of host site without address (e.g., "Euphoric State University")
 address: "British Library, 96 Euston Road, London, NW1 2DB"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria")
 country: "gb"      # lowercase two-letter ISO country code such as "fr" (see https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes)
 language: "en"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)


### PR DESCRIPTION
Software Carpentry Workshop, The Alan Turing Institute